### PR TITLE
Using shorthand notation for object methods breaks apps on iOS < 9 and Android < 5

### DIFF
--- a/www/bugfender.js
+++ b/www/bugfender.js
@@ -100,7 +100,7 @@ sendCrash: function(title, markdown, callback) {
 		window["cordova"].exec(callback, null, "Bugfender", "sendCrash", [title, markdown]);
 },
 
-sendUserFeedback(title, markdown, callback) {
+sendUserFeedback: function(title, markdown, callback) {
 	checkLoaded();
 	if(window["device"] && window["device"].platform != "browser")
 		window["cordova"].exec(callback, null, "Bugfender", "sendUserFeedback", [title, markdown]);


### PR DESCRIPTION
Shorthand notation for object methods is not supported by iOS < 9 and Android < 5 according https://caniuse.com/#feat=mdn-javascript_grammar_shorthand_object_literals

The code was introduced in https://github.com/bugfender/cordova-plugin-bugfender/commit/00274cf52eafe1ac4b770391c8b1542a115f8725