### PR TITLE
Get plugin configuration from preferences if not available as resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ Then use `Bugfender.log()` to log anything you want. Syntax is the same as `cons
 
 For a basic use of Bugfender, that's all you need to do. Read on to learn more advanced options.
 
+## Installing in Ionic with Capacitor
+Install the dependency
+```shell
+npm install --save cordova-plugin-bugfender
+```
+
+In your capacitor.config.ts you can add your app key and configuration:
+
+```typescript
+ cordova: {
+    preferences: {
+      BUGFENDER_APP_KEY: 'xxx',
+    },
+  },
+```
+
 ## Configuration variables
 
 ### Application key

--- a/platforms/android/com/bugfender/sdk/cordova/BugfenderPlugin.java
+++ b/platforms/android/com/bugfender/sdk/cordova/BugfenderPlugin.java
@@ -26,35 +26,39 @@ public class BugfenderPlugin extends CordovaPlugin {
 		private CallbackContext callback = null;
 		public static final int FEEDBACK_REQUEST_CODE = 2222;
 
+		private String getConfigValue(String name, String defaultValue) {
+			int id = this.cordova.getActivity().getResources().getIdentifier(name, "string", this.cordova.getActivity().getPackageName());
+			if (id != 0) {
+				return this.cordova.getActivity().getString(id);
+			} else {
+				return this.preferences.getString(name, defaultValue);
+			}
+		}
+
 		@Override
 		protected void pluginInitialize() {
-			int hideDeviceNameResId = this.cordova.getActivity().getResources().getIdentifier("BUGFENDER_HIDE_DEVICE_NAME", "string", this.cordova.getActivity().getPackageName());
-			String hideDeviceName = this.cordova.getActivity().getString(hideDeviceNameResId);
+			String hideDeviceName = getConfigValue("BUGFENDER_HIDE_DEVICE_NAME", "unset");
 		    if (!"unset".equals(hideDeviceName)) {
 				Bugfender.overrideDeviceName("Unknown");
 			}
 
-			int baseURLResId = this.cordova.getActivity().getResources().getIdentifier("BUGFENDER_BASE_URL", "string", this.cordova.getActivity().getPackageName());
-			String baseURL = this.cordova.getActivity().getString(baseURLResId);
+			String baseURL = getConfigValue("BUGFENDER_BASE_URL", "unset");
 		    if (!"unset".equals(baseURL)) {
 				Bugfender.setBaseUrl(baseURL);
 			}
 
-			int apiURLResId = this.cordova.getActivity().getResources().getIdentifier("BUGFENDER_API_URL", "string", this.cordova.getActivity().getPackageName());
-			String apiURL = this.cordova.getActivity().getString(apiURLResId);
+			String apiURL = getConfigValue("BUGFENDER_API_URL", "unset");
 		    if (!"unset".equals(apiURL)) {
 				Bugfender.setApiUrl(apiURL);
 			}
 
-			int appResId = this.cordova.getActivity().getResources().getIdentifier("BUGFENDER_APP_KEY", "string", this.cordova.getActivity().getPackageName());
-			String key = this.cordova.getActivity().getString(appResId);
+			String key = getConfigValue("BUGFENDER_APP_KEY", "");
 		    if (key.length() == 0) {
 				System.out.println("Please set BUGFENDER_APP_KEY in config.xml");
 				return;
 			}
 
-			int enablesResId = this.cordova.getActivity().getResources().getIdentifier("BUGFENDER_AUTOMATIC", "string", this.cordova.getActivity().getPackageName());
-			String enabled = this.cordova.getActivity().getString(enablesResId);
+			String enabled = getConfigValue("BUGFENDER_AUTOMATIC", "ALL");
 		    if (enabled.length() == 0 || "ALL".equals(enabled))
 				enabled = "UI,LOG,CRASH";
 			List<String> enables = Arrays.asList(enabled.split(","));


### PR DESCRIPTION
Since I'm still running Capacitor 3.7 I cannot use the capacitor Bugfender plugin. Configuration can now be done also via the capacitor.config.ts. In the CapacitorConfig add:
```
  cordova: {
    preferences: {
      BUGFENDER_APP_KEY: 'xxx',
    },
  },
```

Sorry for all the whitespace changes, our formatter configs seem to be different. Feel free to reformat.